### PR TITLE
Fix-Infinite: Return if Steam it's not init

### DIFF
--- a/com.rlabrecque.steamworks.net/Runtime/Steam.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/Steam.cs
@@ -321,6 +321,7 @@ namespace Steamworks {
 			if (m_pSteamClient == IntPtr.Zero)
 			{
 				failureReason |= FailureReason.m_pSteamClient;
+				return failureReason;
 			}
 
 			m_pSteamUser = SteamClient.GetISteamUser(hSteamUser, hSteamPipe, Constants.STEAMUSER_INTERFACE_VERSION);


### PR DESCRIPTION
Fixes AL not starting without Steam. If the `m_pSteamClien` was 0 the subsequent calls were going to create a infinite loop.  